### PR TITLE
added homekit ID to be displayed with index.html

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -49,8 +49,8 @@ input[type=submit][disabled] {
 <body>
     <div class="container">
         <h1>Join WiFi network</h1>
-	<!-- part HTML_SETTINGS_HEADER_ACCESSORYID -->
-	<p><b>Homekit Accessory ID:</b><br>  {{accessoryID}}  </p>
+	<!-- part HTML_SETTINGS_HEADER_CUSTOM_SECTION -->
+	{{custom_section}}
 	<!-- part HTML_SETTINGS_HEADER_SETTINGS -->
         <form action="/settings" method="get">
             <input type="submit" id="refresh" value="⟲ Refresh" />

--- a/content/index.html
+++ b/content/index.html
@@ -49,8 +49,8 @@ input[type=submit][disabled] {
 <body>
     <div class="container">
         <h1>Join WiFi network</h1>
-	<!-- part HTML_SETTINGS_HEADER_CUSTOM_SECTION -->
-	{{custom_section}}
+	<!-- part HTML_SETTINGS_HEADER_CUSTOM_HTML_SECTION -->
+	{{custom_html_section}}
 	<!-- part HTML_SETTINGS_HEADER_SETTINGS -->
         <form action="/settings" method="get">
             <input type="submit" id="refresh" value="⟲ Refresh" />

--- a/content/index.html
+++ b/content/index.html
@@ -48,9 +48,9 @@ input[type=submit][disabled] {
 </head>
 <body>
     <div class="container">
-       	<!-- part HTML_SETTINGS_HEADER_CUSTOM_SECTION -->
+       	<!-- part HTML_SETTINGS_CUSTOM_SECTION -->
 	{{custom_section}}
-	<!-- part HTML_SETTINGS_HEADER_SETTINGS -->
+	<!-- part HTML_SETTINGS_BODY -->
         <h1>Join WiFi network</h1>
 	 <form action="/settings" method="get">
             <input type="submit" id="refresh" value="⟲ Refresh" />

--- a/content/index.html
+++ b/content/index.html
@@ -49,6 +49,9 @@ input[type=submit][disabled] {
 <body>
     <div class="container">
         <h1>Join WiFi network</h1>
+	<!-- part HTML_SETTINGS_HEADER_ACCESSORYID -->
+	<p><b>Homekit Accessory ID:</b><br>  {{accessoryID}}  </p>
+	<!-- part HTML_SETTINGS_HEADER_SETTINGS -->
         <form action="/settings" method="get">
             <input type="submit" id="refresh" value="⟲ Refresh" />
         </form>

--- a/content/index.html
+++ b/content/index.html
@@ -48,10 +48,10 @@ input[type=submit][disabled] {
 </head>
 <body>
     <div class="container">
-       	<!-- part HTML_SETTINGS_CUSTOM_SECTION -->
-	{{custom_section}}
-	<!-- part HTML_SETTINGS_BODY -->
-        <h1>Join WiFi network</h1>
+       	 <!-- part HTML_SETTINGS_CUSTOM_HTML -->
+	 {{custom_html}}
+	 <!-- part HTML_SETTINGS_BODY -->
+         <h1>Join WiFi network</h1>
 	 <form action="/settings" method="get">
             <input type="submit" id="refresh" value="⟲ Refresh" />
         </form>

--- a/content/index.html
+++ b/content/index.html
@@ -48,11 +48,11 @@ input[type=submit][disabled] {
 </head>
 <body>
     <div class="container">
-        <h1>Join WiFi network</h1>
-	<!-- part HTML_SETTINGS_HEADER_CUSTOM_HTML_SECTION -->
-	{{custom_html_section}}
+       	<!-- part HTML_SETTINGS_HEADER_CUSTOM_SECTION -->
+	{{custom_section}}
 	<!-- part HTML_SETTINGS_HEADER_SETTINGS -->
-        <form action="/settings" method="get">
+        <h1>Join WiFi network</h1>
+	 <form action="/settings" method="get">
             <input type="submit" id="refresh" value="⟲ Refresh" />
         </form>
         <form action="/settings" method="post">

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -12,4 +12,4 @@ void wifi_config_reset();
 void wifi_config_get(char **ssid, char **password);
 void wifi_config_set(const char *ssid, const char *password);
 
-void custom_section_set(char *param_custom_section); 
+void wifi_config_custom_section_set(char *custom_section); 

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -12,4 +12,4 @@ void wifi_config_reset();
 void wifi_config_get(char **ssid, char **password);
 void wifi_config_set(const char *ssid, const char *password);
 
-void wifi_config_custom_section_set(char *custom_section); 
+void wifi_config_set_custom_html(char *html);

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -12,4 +12,4 @@ void wifi_config_reset();
 void wifi_config_get(char **ssid, char **password);
 void wifi_config_set(const char *ssid, const char *password);
 
-void custom_section_set(char *param_custom_section); 
+void custom_html_section_set(char *param_custom_html_section); 

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -12,4 +12,4 @@ void wifi_config_reset();
 void wifi_config_get(char **ssid, char **password);
 void wifi_config_set(const char *ssid, const char *password);
 
-void custom_html_section_set(char *param_custom_html_section); 
+void custom_section_set(char *param_custom_section); 

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -11,6 +11,5 @@ void wifi_config_init2(const char *ssid_prefix, const char *password, void (*on_
 void wifi_config_reset();
 void wifi_config_get(char **ssid, char **password);
 void wifi_config_set(const char *ssid, const char *password);
-void accessory_id_set(const char *accessory_id);
-void accessory_id_get(char **accessory_id);
 
+void custom_section_set(char *param_custom_section); 

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -11,3 +11,6 @@ void wifi_config_init2(const char *ssid_prefix, const char *password, void (*on_
 void wifi_config_reset();
 void wifi_config_get(char **ssid, char **password);
 void wifi_config_set(const char *ssid, const char *password);
+void accessory_id_set(const char *accessory_id);
+void accessory_id_get(char **accessory_id);
+

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -59,7 +59,7 @@ typedef struct {
 
 
 static wifi_config_context_t *context = NULL;
-static char* custom_section = NULL;
+static char* custom_html_section = NULL;
 
 typedef struct _client {
     int fd;
@@ -218,10 +218,10 @@ static void wifi_config_server_on_settings(client_t *client) {
 
 
     //only send custom section if initialised
-    if( custom_section != NULL && strlen(custom_section) > 0 ) {
-	uint8_t buffer_size = strlen(html_settings_header_custom_section) + strlen(custom_section);
+    if( custom_html_section != NULL && strlen(custom_html_section) > 0 ) {
+	uint8_t buffer_size = strlen(html_settings_header_custom_html_section) + strlen(custom_html_section);
 	char* buffer = (char*) calloc( buffer_size, 0 );
-	snprintf( buffer, buffer_size, html_settings_header_custom_section, custom_section);
+	snprintf( buffer, buffer_size, html_settings_header_custom_html_section, custom_html_section);
 
 	client_send_chunk(client, buffer); //send custom section
 	free(buffer);
@@ -456,7 +456,7 @@ static void http_task(void *arg) {
 
 
 static void http_start() {
-    xTaskCreate(http_task, "wifi_config HTTP", 512, NULL, 2, &context->http_task_handle);
+    xTaskCreate(http_task, "wifi_config HTTP", 768, NULL, 2, &context->http_task_handle);
 }
 
 
@@ -810,8 +810,8 @@ void wifi_config_set(const char *ssid, const char *password) {
 /**
  * sets the custom section to use with the AP homepage
  * */
-void custom_section_set(char *param_custom_section) {
-    custom_section = param_custom_section;
+void custom_html_section_set(char *param_custom_html_section) {
+    custom_html_section = param_custom_html_section;
 }
 
 

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -48,7 +48,7 @@ typedef enum {
 typedef struct {
     char *ssid_prefix;
     char *password;
-    char *custom_section;
+    char *custom_html;
     void (*on_wifi_ready)();  // deprecated
     void (*on_event)(wifi_config_event_t);
 
@@ -216,13 +216,11 @@ static void wifi_config_server_on_settings(client_t *client) {
     client_send(client, http_prologue, sizeof(http_prologue)-1);
     client_send_chunk(client, html_settings_header);
 
-
-    //only send custom section if initialised
-    if(context->custom_section != NULL && strlen(context->custom_section) > 0) {
-	uint8_t buffer_size = strlen(html_settings_custom_section) + strlen(context->custom_section); //buffer size is the template size + custom section size
-	char* buffer = (char*) calloc( buffer_size, sizeof(char) ); //fill up the buffer with zeros
-	snprintf( buffer, buffer_size, html_settings_custom_section, context->custom_section); //fill in template with the custom_section content
-	client_send_chunk(client, buffer); //send custom section
+    if (context->custom_html != NULL && context->custom_html[0] > 0) {
+	uint8_t buffer_size = strlen(html_settings_custom_html) + strlen(context->custom_html); 
+	char* buffer = (char*) calloc(buffer_size, sizeof(char)); //fill up the buffer with zeros
+	snprintf(buffer, buffer_size, html_settings_custom_html, context->custom_html); //fill in template with the custom_html content
+	client_send_chunk(client, buffer); 
 	free(buffer);
     }
 
@@ -806,15 +804,13 @@ void wifi_config_set(const char *ssid, const char *password) {
     sysparam_set_string("wifi_password", password);
 }
 
-/**
- * sets the custom section to use with the AP homepage
- * at this point context may not be initialised yet, 
- * so initialise if doesn't exist
- * */
-void wifi_config_custom_section_set(char *custom_section) {
-    if(context == NULL) { 
+void wifi_config_set_custom_html(char *html) {
+    if (context == NULL) { 
 	ERROR("cannot set custom html content, wifi configuration not initialised yet"); 
-    } else context->custom_section = custom_section;
+	return;
+    } 
+
+    context->custom_html = html;
 }
 
 

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -60,7 +60,6 @@ typedef struct {
 
 static wifi_config_context_t *context = NULL;
 
-
 typedef struct _client {
     int fd;
 
@@ -217,6 +216,18 @@ static void wifi_config_server_on_settings(client_t *client) {
     client_send_chunk(client, html_settings_header);
 
     char buffer[64];
+    char *accessory_id = "111-22-333";
+    accessory_id_get(&accessory_id);
+
+    snprintf(
+	buffer, sizeof(buffer),
+        html_settings_header_accessoryid,	
+	accessory_id
+    );
+
+    client_send_chunk(client, buffer); /*send accessory ID*/
+    client_send_chunk(client, html_settings_header_settings);
+
     if (xSemaphoreTake(wifi_networks_mutex, 5000 / portTICK_PERIOD_MS)) {
         wifi_network_info_t *net = wifi_networks;
         while (net) {
@@ -793,3 +804,13 @@ void wifi_config_set(const char *ssid, const char *password) {
     sysparam_set_string("wifi_ssid", ssid);
     sysparam_set_string("wifi_password", password);
 }
+
+void accessory_id_set(const char *accessory_id) {
+    sysparam_set_string("accessory_id", accessory_id);
+}
+
+void accessory_id_get(char **accessory_id) {
+    sysparam_get_string("accessory_id", accessory_id);
+}
+
+

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -218,13 +218,10 @@ static void wifi_config_server_on_settings(client_t *client) {
 
 
     //only send custom section if initialised
-    if( custom_section != NULL ) {
-	char* buffer = (char*) malloc( sizeof(custom_section) );
-	snprintf(
-	    buffer, sizeof(buffer) + sizeof(custom_section),
-            html_settings_header_custom_section,
-	    custom_section
-	);
+    if( custom_section != NULL && strlen(custom_section) > 0 ) {
+	uint8_t buffer_size = strlen(html_settings_header_custom_section) + strlen(custom_section);
+	char* buffer = (char*) calloc( buffer_size, 0 );
+	snprintf( buffer, buffer_size, html_settings_header_custom_section, custom_section);
 
 	client_send_chunk(client, buffer); //send custom section
 	free(buffer);

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -60,7 +60,6 @@ typedef struct {
 
 
 static wifi_config_context_t *context = NULL;
-static char* custom_section = NULL;
 
 typedef struct _client {
     int fd;
@@ -219,10 +218,10 @@ static void wifi_config_server_on_settings(client_t *client) {
 
 
     //only send custom section if initialised
-    if( custom_section != NULL && strlen(custom_section) > 0 ) {
-	uint8_t buffer_size = strlen(html_settings_header_custom_section) + strlen(custom_section); //buffer size is the template size + custom section size
+    if( context->custom_section != NULL && strlen(context->custom_section) > 0 ) {
+	uint8_t buffer_size = strlen(html_settings_header_custom_section) + strlen(context->custom_section); //buffer size is the template size + custom section size
 	char* buffer = (char*) calloc( buffer_size, sizeof(char) ); //fill up the buffer with zeros
-	snprintf( buffer, buffer_size, html_settings_header_custom_section, custom_section); //fill in template with the custom_section content
+	snprintf( buffer, buffer_size, html_settings_header_custom_section, context->custom_section); //fill in template with the custom_section content
 	client_send_chunk(client, buffer); //send custom section
 	free(buffer);
     }
@@ -754,8 +753,10 @@ void wifi_config_init(const char *ssid_prefix, const char *password, void (*on_w
         return;
     }
 
-    context = malloc(sizeof(wifi_config_context_t));
-    memset(context, 0, sizeof(*context));
+    if( context == NULL ) {
+	context = malloc(sizeof(wifi_config_context_t));
+	memset(context, 0, sizeof(*context));
+    }
 
     context->ssid_prefix = strndup(ssid_prefix, 33-7);
     if (password)
@@ -809,9 +810,16 @@ void wifi_config_set(const char *ssid, const char *password) {
 
 /**
  * sets the custom section to use with the AP homepage
+ * at this point context may not be initialised yet, 
+ * so initialise if doesn't exist
  * */
-void custom_section_set(char *param_custom_section) {
-    custom_section = param_custom_section;
+void custom_section_set(char *custom_section) {
+    if( context == NULL ) {
+	context = malloc(sizeof(wifi_config_context_t));
+	memset(context, 0, sizeof(*context));
+    }
+
+    context->custom_section = custom_section;
 }
 
 

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -218,7 +218,7 @@ static void wifi_config_server_on_settings(client_t *client) {
 
 
     //only send custom section if initialised
-    if( context->custom_section != NULL && strlen(context->custom_section) > 0 ) {
+    if(context->custom_section != NULL && strlen(context->custom_section) > 0) {
 	uint8_t buffer_size = strlen(html_settings_header_custom_section) + strlen(context->custom_section); //buffer size is the template size + custom section size
 	char* buffer = (char*) calloc( buffer_size, sizeof(char) ); //fill up the buffer with zeros
 	snprintf( buffer, buffer_size, html_settings_header_custom_section, context->custom_section); //fill in template with the custom_section content
@@ -753,10 +753,8 @@ void wifi_config_init(const char *ssid_prefix, const char *password, void (*on_w
         return;
     }
 
-    if( context == NULL ) {
-	context = malloc(sizeof(wifi_config_context_t));
-	memset(context, 0, sizeof(*context));
-    }
+    context = malloc(sizeof(wifi_config_context_t));
+    memset(context, 0, sizeof(*context));
 
     context->ssid_prefix = strndup(ssid_prefix, 33-7);
     if (password)
@@ -814,12 +812,8 @@ void wifi_config_set(const char *ssid, const char *password) {
  * so initialise if doesn't exist
  * */
 void custom_section_set(char *custom_section) {
-    if( context == NULL ) {
-	context = malloc(sizeof(wifi_config_context_t));
-	memset(context, 0, sizeof(*context));
-    }
-
-    context->custom_section = custom_section;
+    if(context == NULL) ERROR("cannot set custom html content, wifi configuration not initialised yet");
+    else context->custom_section = custom_section;
 }
 
 

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -455,7 +455,7 @@ static void http_task(void *arg) {
 
 
 static void http_start() {
-    xTaskCreate(http_task, "wifi_config HTTP", 768, NULL, 2, &context->http_task_handle);
+    xTaskCreate(http_task, "wifi_config HTTP", 512, NULL, 2, &context->http_task_handle);
 }
 
 

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -811,7 +811,7 @@ void wifi_config_set(const char *ssid, const char *password) {
  * at this point context may not be initialised yet, 
  * so initialise if doesn't exist
  * */
-void custom_section_set(char *custom_section) {
+void wifi_config_custom_section_set(char *custom_section) {
     if(context == NULL) { 
 	ERROR("cannot set custom html content, wifi configuration not initialised yet"); 
     } else context->custom_section = custom_section;

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -219,14 +219,14 @@ static void wifi_config_server_on_settings(client_t *client) {
 
     //only send custom section if initialised
     if(context->custom_section != NULL && strlen(context->custom_section) > 0) {
-	uint8_t buffer_size = strlen(html_settings_header_custom_section) + strlen(context->custom_section); //buffer size is the template size + custom section size
+	uint8_t buffer_size = strlen(html_settings_custom_section) + strlen(context->custom_section); //buffer size is the template size + custom section size
 	char* buffer = (char*) calloc( buffer_size, sizeof(char) ); //fill up the buffer with zeros
-	snprintf( buffer, buffer_size, html_settings_header_custom_section, context->custom_section); //fill in template with the custom_section content
+	snprintf( buffer, buffer_size, html_settings_custom_section, context->custom_section); //fill in template with the custom_section content
 	client_send_chunk(client, buffer); //send custom section
 	free(buffer);
     }
 
-    client_send_chunk(client, html_settings_header_settings);
+    client_send_chunk(client, html_settings_body);
 
     if (xSemaphoreTake(wifi_networks_mutex, 5000 / portTICK_PERIOD_MS)) {
 	char buffer[64];
@@ -812,8 +812,9 @@ void wifi_config_set(const char *ssid, const char *password) {
  * so initialise if doesn't exist
  * */
 void custom_section_set(char *custom_section) {
-    if(context == NULL) ERROR("cannot set custom html content, wifi configuration not initialised yet");
-    else context->custom_section = custom_section;
+    if(context == NULL) { 
+	ERROR("cannot set custom html content, wifi configuration not initialised yet"); 
+    } else context->custom_section = custom_section;
 }
 
 

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -48,6 +48,7 @@ typedef enum {
 typedef struct {
     char *ssid_prefix;
     char *password;
+    char *custom_section;
     void (*on_wifi_ready)();  // deprecated
     void (*on_event)(wifi_config_event_t);
 
@@ -59,7 +60,7 @@ typedef struct {
 
 
 static wifi_config_context_t *context = NULL;
-static char* custom_html_section = NULL;
+static char* custom_section = NULL;
 
 typedef struct _client {
     int fd;
@@ -218,11 +219,10 @@ static void wifi_config_server_on_settings(client_t *client) {
 
 
     //only send custom section if initialised
-    if( custom_html_section != NULL && strlen(custom_html_section) > 0 ) {
-	uint8_t buffer_size = strlen(html_settings_header_custom_html_section) + strlen(custom_html_section);
-	char* buffer = (char*) calloc( buffer_size, 0 );
-	snprintf( buffer, buffer_size, html_settings_header_custom_html_section, custom_html_section);
-
+    if( custom_section != NULL && strlen(custom_section) > 0 ) {
+	uint8_t buffer_size = strlen(html_settings_header_custom_section) + strlen(custom_section); //buffer size is the template size + custom section size
+	char* buffer = (char*) calloc( buffer_size, sizeof(char) ); //fill up the buffer with zeros
+	snprintf( buffer, buffer_size, html_settings_header_custom_section, custom_section); //fill in template with the custom_section content
 	client_send_chunk(client, buffer); //send custom section
 	free(buffer);
     }
@@ -810,8 +810,8 @@ void wifi_config_set(const char *ssid, const char *password) {
 /**
  * sets the custom section to use with the AP homepage
  * */
-void custom_html_section_set(char *param_custom_html_section) {
-    custom_html_section = param_custom_html_section;
+void custom_section_set(char *param_custom_section) {
+    custom_section = param_custom_section;
 }
 
 

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -216,7 +216,7 @@ static void wifi_config_server_on_settings(client_t *client) {
     client_send_chunk(client, html_settings_header);
 
     char buffer[64];
-    char *accessory_id = "111-22-333";
+    char accessory_id[12];
     accessory_id_get(&accessory_id);
 
     snprintf(


### PR DESCRIPTION
accessory ID can be set in the project (accessory_id_set) and displayed with index.html

I am also generating the accessoryt ID in the main program with the following code:

/**
 * generates accessory ID from the chipID, turns 32 bit chipID into 4-byte chunks and gets modulo 9 from each
 * */
void accessory_id_init() {
    uint32_t chipid = sdk_system_get_chip_id();
    uint8_t accessory_id_digits[] = { chipid >> 0 & 0xf % 9,  chipid >> 4 & 0xf % 9, chipid >> 8 & 0xf % 9, 
    	chipid >> 12 & 0xf % 9, chipid >> 16 & 0xf % 9, chipid >> 20 & 0xf % 9, chipid >> 24 & 0xf % 9, chipid >> 28 & 0xf % 9 }; 
    config.password = (char*) malloc( 11 * sizeof(char));
    snprintf(config.password, 11, "%u%u%u-%u%u-%u%u%u", accessory_id_digits[0], accessory_id_digits[1], accessory_id_digits[2], 
    	                               accessory_id_digits[3], accessory_id_digits[4], accessory_id_digits[5], accessory_id_digits[6], accessory_id_digits[7]);
    
    //set accessory ID to the generated one. This is used in the wifi-config library
    accessory_id_set(config.password);
}