### PR TITLE
Support for custom hostnames

### DIFF
--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -6,7 +6,7 @@ typedef enum {
 } wifi_config_event_t;
 
 void wifi_config_init(const char *ssid_prefix, const char *password, void (*on_wifi_ready)());
-void wifi_config_init2(const char *ssid_prefix, const char *password, void (*on_event)(wifi_config_event_t));
+void wifi_config_init2(const char *ssid_prefix, const char *password, void (*on_event)(wifi_config_event_t), const char *custom_hostname);
 
 void wifi_config_reset();
 void wifi_config_get(char **ssid, char **password);


### PR DESCRIPTION
With this PR I'm attempting to bring custom hostnames into esp-wifi-config. 
I found the code at RavenSystem/haa repository and thought it would be helpful to have this into the rest custom homekit devices. 

I have altered the definition of wifi_config_init2 function. This will put users who are using this version of init to re-write their code. 

If this is not acceptable, then someone may propose a different way. 

At the homekit accessory makefile, I also put the following: 
EXTRA_CFLAGS += -DLWIP_NETIF_HOSTNAME=1 