### PR TITLE
Add AP start/stop events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/include/wifi_config.h
+++ b/include/wifi_config.h
@@ -3,6 +3,8 @@
 typedef enum {
     WIFI_CONFIG_CONNECTED = 1,
     WIFI_CONFIG_DISCONNECTED = 2,
+    WIFI_CONFIG_AP_START = 3,
+    WIFI_CONFIG_AP_STOP = 4
 } wifi_config_event_t;
 
 void wifi_config_init(const char *ssid_prefix, const char *password, void (*on_wifi_ready)());

--- a/src/wifi_config.c
+++ b/src/wifi_config.c
@@ -682,6 +682,8 @@ static void wifi_config_softap_start() {
 
     dns_start();
     http_start();
+    if (context->on_event)
+        context->on_event(WIFI_CONFIG_AP_START);
 }
 
 
@@ -690,6 +692,8 @@ static void wifi_config_softap_stop() {
     dns_stop();
     http_stop();
     sdk_wifi_set_opmode(STATION_MODE);
+    if (context->on_event)
+        context->on_event(WIFI_CONFIG_AP_STOP);
 }
 
 


### PR DESCRIPTION
Add two new values to `wifi_config_event_t`: `WIFI_CONFIG_AP_START` and `WIFI_CONFIG_AP_STOP`

When `wifi_config_init2()` is used and the client has provided a callback, it will be invoked when the library enters and exits AP mode. This allows the client to give the user some sort of feedback (e.g. blink an LED) that an action needs to be taken.